### PR TITLE
Migrate to ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+dist/
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.3 (2020-05-14)
+
+* Migrate to ESM
+
 ## 0.3.2 (2020-05-06)
 
 * Also remove numeric separators in Literal's `bigint` property

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This module provides a plugin that can be used to extend the Acorn `Parser` clas
 You can either choose to use it via CommonJS (for example in Node.js) like this
 
 ```javascript
-const [Parser} = require('acorn');
+const {Parser} = require('acorn');
 const numericSeparator = require('acorn-numeric-separator');
 Parser.extend(numericSeparator).parse('100_000');
 ```

--- a/README.md
+++ b/README.md
@@ -8,12 +8,21 @@ It implements support for numeric separators as defined in the stage 3 proposal 
 
 ## Usage
 
-This module provides a plugin that can be used to extend the Acorn `Parser` class to parse numeric separators:
+This module provides a plugin that can be used to extend the Acorn `Parser` class to parse numeric separators.
+You can either choose to use it via CommonJS (for example in Node.js) like this
 
 ```javascript
-var acorn = require('acorn');
-var numericSeparator = require('acorn-numeric-separator');
-acorn.Parser.extend(numericSeparator).parse('100_000');
+const [Parser} = require('acorn');
+const numericSeparator = require('acorn-numeric-separator');
+Parser.extend(numericSeparator).parse('100_000');
+```
+
+or as an ECMAScript module like this:
+
+```javascript
+import {Parser} from 'acorn';
+import numericSeparator from 'path/to/acorn-numeric-separator.mjs';
+Parser.extend(numericSeparator).parse('100_000');
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ or as an ECMAScript module like this:
 
 ```javascript
 import {Parser} from 'acorn';
-import numericSeparator from 'path/to/acorn-numeric-separator.mjs';
+import numericSeparator from 'acorn-numeric-separator';
 Parser.extend(numericSeparator).parse('100_000');
 ```
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "contributors": [
     "Adrian Heine <mail@adrianheine.de>"
   ],
+  "main": "dist/acorn-numeric-separator.js",
+  "module": "dist/acorn-numeric-separator.mjs",
   "engines": {
     "node": ">=4.8.2"
   },
@@ -14,6 +16,8 @@
   },
   "license": "MIT",
   "scripts": {
+    "build": "rollup -c rollup.config.js",
+    "prepare": "npm run build",
     "test": "mocha",
     "test:test262": "node run_test262.js",
     "lint": "eslint -c .eslintrc.json ."
@@ -21,12 +25,13 @@
   "peerDependencies": {
     "acorn": "^6 || ^7"
   },
-  "version": "0.3.2",
+  "version": "0.3.3",
   "devDependencies": {
     "acorn": "^7",
     "eslint": "^6",
     "eslint-plugin-node": "^11",
     "mocha": "^7",
+    "rollup": "^2.10.0",
     "test262": "git+https://github.com/tc39/test262.git#a3c7d30cbb68ebcdc522df362dffbc31465b0d1d",
     "test262-parser-runner": "^0.5.0"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,15 @@
+export default {
+  input: "src/index.js",
+  output: [
+    {
+      file: "dist/acorn-numeric-separator.js",
+      format: "cjs",
+      sourcemap: true
+    },
+    {
+      file: "dist/acorn-numeric-separator.mjs",
+      format: "es",
+      sourcemap: true
+    }
+  ]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-"use strict"
-
 function withoutAcornBigInt(acorn, Parser) {
   return class extends Parser {
     readInt(radix, len) {
@@ -142,7 +140,7 @@ function withAcornBigInt(acorn, Parser) {
   }
 }
 
-module.exports = function(Parser) {
+export default function numericSeparator(Parser) {
   const acorn = Parser.acorn || require("acorn")
   const withAcornBigIntSupport = (acorn.version.startsWith("6.") && !(acorn.version.startsWith("6.0.") || acorn.version.startsWith("6.1."))) || acorn.version.startsWith("7.")
 


### PR DESCRIPTION
We've recently migrated Chrome DevTools to ESM, and have traditionally
been using acorn as the parser for various features including the
prettifier. In the context of https://crbug.com/1009927 we are looking
into including numeric separator support in Chrome DevTools via this
plugin, and in order to make that easier with our build system, I've
added support for ESM output here in addition to the CJS output.